### PR TITLE
feat: add laporan benerimaan barang module

### DIFF
--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/README.md
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/README.md
@@ -1,0 +1,21 @@
+# Laporan Penerimaan Barang API
+
+Kumpulan request Bruno untuk modul Laporan Penerimaan Barang pada sistem Backend Distribusi Retail.
+
+## Base URL
+```
+http://localhost:5050/api/v1/laporan-penerimaan-barang
+```
+
+## Autentikasi
+Seluruh endpoint membutuhkan header Authorization dengan Bearer Token yang valid. Nilai token dapat diatur melalui environment variable `access_token` pada workspace Bruno.
+
+## Daftar Endpoint
+1. **Create Laporan** – `POST /`
+2. **Get All Laporan** – `GET /`
+3. **Get Laporan By ID** – `GET /:id`
+4. **Update Laporan** – `PUT /:id`
+5. **Delete Laporan** – `DELETE /:id`
+6. **Search Laporan** – `GET /search`
+
+Setiap request contoh sudah dilengkapi dengan payload dan parameter dasar yang dapat disesuaikan sesuai kebutuhan pengujian.

--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/create.bru
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/create.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Create Laporan Penerimaan Barang
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:5050/api/v1/laporan-penerimaan-barang
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+body:json {
+  {
+    "purchaseOrderId": "{{purchase_order_id}}",
+    "customerId": "{{customer_id}}",
+    "tanggal_po": "2024-09-24",
+    "alamat_customer": "Jl. Contoh No. 123, Jakarta",
+    "termin_bayar": "{{term_of_payment_id}}",
+    "statusId": "{{status_id}}",
+    "files": [
+      "{{file_id_1}}",
+      "{{file_id_2}}"
+    ]
+  }
+}

--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/delete.bru
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/delete.bru
@@ -1,0 +1,14 @@
+meta {
+  name: Delete Laporan Penerimaan Barang
+  type: http
+  seq: 5
+}
+
+delete {
+  url: http://localhost:5050/api/v1/laporan-penerimaan-barang/{{laporan_id}}
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/getAll.bru
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/getAll.bru
@@ -1,0 +1,14 @@
+meta {
+  name: Get All Laporan Penerimaan Barang
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:5050/api/v1/laporan-penerimaan-barang?page=1&limit=10
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/getById.bru
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/getById.bru
@@ -1,0 +1,14 @@
+meta {
+  name: Get Laporan Penerimaan Barang By ID
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost:5050/api/v1/laporan-penerimaan-barang/{{laporan_id}}
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/search.bru
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/search.bru
@@ -1,0 +1,14 @@
+meta {
+  name: Search Laporan Penerimaan Barang
+  type: http
+  seq: 6
+}
+
+get {
+  url: http://localhost:5050/api/v1/laporan-penerimaan-barang/search?q=contoh&page=1&limit=10
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/backend-distribusi-retail-collection/laporan-penerimaan-barang/update.bru
+++ b/backend-distribusi-retail-collection/laporan-penerimaan-barang/update.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Update Laporan Penerimaan Barang
+  type: http
+  seq: 4
+}
+
+put {
+  url: http://localhost:5050/api/v1/laporan-penerimaan-barang/{{laporan_id}}
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+body:json {
+  {
+    "tanggal_po": "2024-09-25",
+    "alamat_customer": "Jl. Contoh Raya No. 456, Bandung",
+    "statusId": "{{status_id}}",
+    "files": [
+      "{{file_id_2}}"
+    ]
+  }
+}

--- a/prisma/migrations/20240924120000_add_laporan_penerimaan_barang/migration.sql
+++ b/prisma/migrations/20240924120000_add_laporan_penerimaan_barang/migration.sql
@@ -1,0 +1,37 @@
+CREATE TABLE "laporan_penerimaan_barang" (
+    "id" TEXT NOT NULL,
+    "purchase_order_id" TEXT,
+    "tanggal_po" TIMESTAMP(3),
+    "customer_id" TEXT,
+    "alamat_customer" TEXT,
+    "termin_bayar" TEXT,
+    "status_id" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT NOT NULL,
+    "updatedBy" TEXT NOT NULL,
+    CONSTRAINT "laporan_penerimaan_barang_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "laporan_penerimaan_barang"
+    ADD CONSTRAINT "laporan_penerimaan_barang_purchase_order_id_fkey"
+    FOREIGN KEY ("purchase_order_id") REFERENCES "purchase_orders" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "laporan_penerimaan_barang"
+    ADD CONSTRAINT "laporan_penerimaan_barang_customer_id_fkey"
+    FOREIGN KEY ("customer_id") REFERENCES "customers" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "laporan_penerimaan_barang"
+    ADD CONSTRAINT "laporan_penerimaan_barang_termin_bayar_fkey"
+    FOREIGN KEY ("termin_bayar") REFERENCES "term_of_payment" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "laporan_penerimaan_barang"
+    ADD CONSTRAINT "laporan_penerimaan_barang_status_id_fkey"
+    FOREIGN KEY ("status_id") REFERENCES "statuses" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "file_uploaded"
+    ADD COLUMN "laporan_penerimaan_barang_id" TEXT;
+
+ALTER TABLE "file_uploaded"
+    ADD CONSTRAINT "file_uploaded_laporan_penerimaan_barang_id_fkey"
+    FOREIGN KEY ("laporan_penerimaan_barang_id") REFERENCES "laporan_penerimaan_barang" ("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,17 +8,17 @@ datasource db {
 }
 
 model User {
-  id          String       @id @default(cuid())
-  email       String       @unique
-  username    String       @unique
-  password    String
-  firstName   String?
-  lastName    String?
-  roleId      String
-  isActive    Boolean      @default(true)
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  profile     Profile?
+  id            String         @id @default(cuid())
+  email         String         @unique
+  username      String         @unique
+  password      String
+  firstName     String?
+  lastName      String?
+  roleId        String
+  isActive      Boolean        @default(true)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  profile       Profile?
   role          Role           @relation(fields: [roleId], references: [id])
   auditTrails   AuditTrail[]
   uploadedFiles FileUploaded[]
@@ -72,25 +72,26 @@ model RoleMenu {
 }
 
 model Customer {
-  id               String          @id @default(cuid())
-  namaCustomer     String
-  kodeCustomer     String          @unique
-  groupCustomerId  String
-  NPWP             String?
-  alamatNPWP       String?
-  regionId         String
-  alamatPengiriman String
-  description      String?
-  createdAt        DateTime        @default(now())
-  updatedAt        DateTime        @updatedAt
-  createdBy        String
-  updatedBy        String
-  email            String?         @unique
-  phoneNumber      String
-  purchaseOrders   PurchaseOrder[]
-  groupCustomer    GroupCustomer   @relation(fields: [groupCustomerId], references: [id])
-  region           Region          @relation(fields: [regionId], references: [id])
-  itemPrices       ItemPrice[]
+  id                      String                    @id @default(cuid())
+  namaCustomer            String
+  kodeCustomer            String                    @unique
+  groupCustomerId         String
+  NPWP                    String?
+  alamatNPWP              String?
+  regionId                String
+  alamatPengiriman        String
+  description             String?
+  createdAt               DateTime                  @default(now())
+  updatedAt               DateTime                  @updatedAt
+  createdBy               String
+  updatedBy               String
+  email                   String?                   @unique
+  phoneNumber             String
+  purchaseOrders          PurchaseOrder[]
+  groupCustomer           GroupCustomer             @relation(fields: [groupCustomerId], references: [id])
+  region                  Region                    @relation(fields: [regionId], references: [id])
+  itemPrices              ItemPrice[]
+  laporanPenerimaanBarang LaporanPenerimaanBarang[]
 
   @@map("customers")
 }
@@ -114,27 +115,28 @@ model Supplier {
 }
 
 model PurchaseOrder {
-  id                   String                @id @default(cuid())
-  customerId           String
-  createdAt            DateTime              @default(now())
-  updatedAt            DateTime              @updatedAt
-  createdBy            String
-  updatedBy            String
-  po_number            String
-  statusId             String?
-  tanggal_masuk_po     DateTime?
-  tanggal_batas_kirim  DateTime?
-  termin_bayar         String?
-  total_items          Int?
-  supplierId           String?
-  po_type              POType                @default(SINGLE)
-  files                FileUploaded[]
-  purchaseOrderDetails PurchaseOrderDetail[]
-  packings             Packing[]
-  invoices             Invoice[]
-  customer             Customer              @relation(fields: [customerId], references: [id])
-  status               Status?               @relation(fields: [statusId], references: [id])
-  supplier             Supplier?             @relation(fields: [supplierId], references: [id])
+  id                      String                    @id @default(cuid())
+  customerId              String
+  createdAt               DateTime                  @default(now())
+  updatedAt               DateTime                  @updatedAt
+  createdBy               String
+  updatedBy               String
+  po_number               String
+  statusId                String?
+  tanggal_masuk_po        DateTime?
+  tanggal_batas_kirim     DateTime?
+  termin_bayar            String?
+  total_items             Int?
+  supplierId              String?
+  po_type                 POType                    @default(SINGLE)
+  files                   FileUploaded[]
+  purchaseOrderDetails    PurchaseOrderDetail[]
+  packings                Packing[]
+  invoices                Invoice[]
+  customer                Customer                  @relation(fields: [customerId], references: [id])
+  status                  Status?                   @relation(fields: [statusId], references: [id])
+  supplier                Supplier?                 @relation(fields: [supplierId], references: [id])
+  laporanPenerimaanBarang LaporanPenerimaanBarang[]
 
   @@map("purchase_orders")
 }
@@ -145,14 +147,16 @@ model FileUploaded {
   path            String
   mimetype        String
   size            Int
-  purchaseOrderId String?
+  purchaseOrderId           String?
+  laporanPenerimaanBarangId String? @map("laporan_penerimaan_barang_id")
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
   createdBy       String?
   statusId        String?
-  purchaseOrder   PurchaseOrder? @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
-  status          Status?        @relation(fields: [statusId], references: [id])
-  user            User?          @relation(fields: [createdBy], references: [id])
+  purchaseOrder           PurchaseOrder?           @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  status                  Status?                  @relation(fields: [statusId], references: [id])
+  user                    User?                    @relation(fields: [createdBy], references: [id])
+  laporanPenerimaanBarang LaporanPenerimaanBarang? @relation(fields: [laporanPenerimaanBarangId], references: [id], onDelete: SetNull)
 
   @@map("file_uploaded")
 }
@@ -172,6 +176,7 @@ model Status {
   invoiceStatusPembayaran Invoice[]           @relation("InvoiceStatusPembayaran")
   suratJalanStatus        SuratJalan[]        @relation("SuratJalanStatus")
   packingItemStatus       PackingItem[]       @relation("PackingItemStatus")
+  laporanPenerimaanBarang LaporanPenerimaanBarang[]
 
   @@unique([status_code, category])
   @@map("statuses")
@@ -433,28 +438,50 @@ model AuditTrail {
 }
 
 model Region {
-  id           String     @id @default(cuid())
-  kode_region  String     @unique
-  nama_region  String
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-  createdBy    String
-  updatedBy    String
-  customers    Customer[]
+  id          String     @id @default(cuid())
+  kode_region String     @unique
+  nama_region String
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+  createdBy   String
+  updatedBy   String
+  customers   Customer[]
 
   @@map("regions")
 }
 
 model TermOfPayment {
-  id         String   @id @default(cuid())
-  kode_top   String   @unique
-  batas_hari Int
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  createdBy  String
-  updatedBy  String
+  id                      String                    @id @default(cuid())
+  kode_top                String                    @unique
+  batas_hari              Int
+  createdAt               DateTime                  @default(now())
+  updatedAt               DateTime                  @updatedAt
+  createdBy               String
+  updatedBy               String
+  laporanPenerimaanBarang LaporanPenerimaanBarang[]
 
   @@map("term_of_payment")
+}
+
+model LaporanPenerimaanBarang {
+  id              String         @id @default(cuid())
+  purchaseOrderId String?        @map("purchase_order_id")
+  tanggal_po      DateTime?
+  customerId      String?        @map("customer_id")
+  alamat_customer String?
+  termin_bayar    String?        @map("termin_bayar")
+  statusId        String?        @map("status_id")
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+  createdBy       String
+  updatedBy       String
+  purchaseOrder   PurchaseOrder? @relation(fields: [purchaseOrderId], references: [id])
+  customer        Customer?      @relation(fields: [customerId], references: [id])
+  termOfPayment   TermOfPayment? @relation(fields: [termin_bayar], references: [id])
+  status          Status?        @relation(fields: [statusId], references: [id])
+  files           FileUploaded[]
+
+  @@map("laporan_penerimaan_barang")
 }
 
 model Company {
@@ -480,22 +507,22 @@ model Company {
 }
 
 model GroupCustomer {
-  id          String     @id @default(cuid())
-  kode_group  String     @unique
-  nama_group  String
-  alamat      String?
-  npwp        String?
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
-  createdBy   String
-  updatedBy   String
-  customers   Customer[]
+  id         String     @id @default(cuid())
+  kode_group String     @unique
+  nama_group String
+  alamat     String?
+  npwp       String?
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  createdBy  String
+  updatedBy  String
+  customers  Customer[]
 
   @@map("group_customer")
 }
 
 model ItemPrice {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   inventoryId String
   customerId  String
   harga       Float
@@ -504,8 +531,8 @@ model ItemPrice {
   pot2        Float?
   harga2      Float?
   ppn         Float?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
   createdBy   String
   updatedBy   String
   inventory   Inventory @relation(fields: [inventoryId], references: [id])

--- a/prisma/seed-statuses.ts
+++ b/prisma/seed-statuses.ts
@@ -182,6 +182,32 @@ const ALL_STATUSES: StatusData[] = [
     status_name: 'Failed Item',
     status_description: 'Packing detail item has been failed.',
     category: 'Packing Detail Item'
+  },
+
+  // Laporan Penerimaan Barang Status
+  {
+    status_code: 'PENDING LAPORAN PENERIMAAN BARANG',
+    status_name: 'Pending Laporan Penerimaan Barang',
+    status_description: 'Laporan penerimaan barang menunggu diproses',
+    category: 'Laporan Penerimaan Barang'
+  },
+  {
+    status_code: 'PROCESSING LAPORAN PENERIMAAN BARANG',
+    status_name: 'Processing Laporan Penerimaan Barang',
+    status_description: 'Laporan penerimaan barang sedang diproses',
+    category: 'Laporan Penerimaan Barang'
+  },
+  {
+    status_code: 'COMPLETED LAPORAN PENERIMAAN BARANG',
+    status_name: 'Completed Laporan Penerimaan Barang',
+    status_description: 'Laporan penerimaan barang telah selesai diproses',
+    category: 'Laporan Penerimaan Barang'
+  },
+  {
+    status_code: 'FAILED LAPORAN PENERIMAAN BARANG',
+    status_name: 'Failed Laporan Penerimaan Barang',
+    status_description: 'Laporan penerimaan barang gagal diproses',
+    category: 'Laporan Penerimaan Barang'
   }
 ];
 

--- a/src/controllers/laporan-penerimaan-barang.controller.ts
+++ b/src/controllers/laporan-penerimaan-barang.controller.ts
@@ -1,0 +1,86 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { ResponseUtil } from '@/utils/response.util';
+import { LaporanPenerimaanBarangService } from '@/services/laporan-penerimaan-barang.service';
+import {
+  CreateLaporanPenerimaanBarangInput,
+  GetAllLaporanPenerimaanBarangInput,
+  SearchLaporanPenerimaanBarangInput,
+  UpdateLaporanPenerimaanBarangInput,
+} from '@/schemas/laporan-penerimaan-barang.schema';
+
+export class LaporanPenerimaanBarangController {
+  static async create(
+    request: FastifyRequest<{ Body: CreateLaporanPenerimaanBarangInput }>,
+    reply: FastifyReply
+  ) {
+    const userId = request.user?.id || 'system';
+    const result = await LaporanPenerimaanBarangService.createLaporanPenerimaanBarang(
+      request.body,
+      userId
+    );
+    return reply.code(201).send(ResponseUtil.success(result));
+  }
+
+  static async getAll(
+    request: FastifyRequest<{ Querystring: GetAllLaporanPenerimaanBarangInput['query'] }>,
+    reply: FastifyReply
+  ) {
+    const { page = 1, limit = 10 } = request.query;
+    const result = await LaporanPenerimaanBarangService.getAllLaporanPenerimaanBarang(
+      page,
+      limit
+    );
+    return reply.send(ResponseUtil.success(result));
+  }
+
+  static async getById(
+    request: FastifyRequest<{ Params: { id: string } }>,
+    reply: FastifyReply
+  ) {
+    const result = await LaporanPenerimaanBarangService.getLaporanPenerimaanBarangById(
+      request.params.id
+    );
+    return reply.send(ResponseUtil.success(result));
+  }
+
+  static async update(
+    request: FastifyRequest<{
+      Params: { id: string };
+      Body: UpdateLaporanPenerimaanBarangInput['body'];
+    }>,
+    reply: FastifyReply
+  ) {
+    const userId = request.user?.id || 'system';
+    const result = await LaporanPenerimaanBarangService.updateLaporanPenerimaanBarang(
+      request.params.id,
+      request.body,
+      userId
+    );
+    return reply.send(ResponseUtil.success(result));
+  }
+
+  static async delete(
+    request: FastifyRequest<{ Params: { id: string } }>,
+    reply: FastifyReply
+  ) {
+    const userId = request.user?.id || 'system';
+    await LaporanPenerimaanBarangService.deleteLaporanPenerimaanBarang(
+      request.params.id,
+      userId
+    );
+    return reply.code(204).send();
+  }
+
+  static async search(
+    request: FastifyRequest<{ Querystring: SearchLaporanPenerimaanBarangInput['query'] }>,
+    reply: FastifyReply
+  ) {
+    const { q, page = 1, limit = 10 } = request.query;
+    const result = await LaporanPenerimaanBarangService.searchLaporanPenerimaanBarang(
+      q,
+      page,
+      limit
+    );
+    return reply.send(ResponseUtil.success(result));
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -21,6 +21,7 @@ import { termOfPaymentRoutes } from './term-of-payment.routes';
 import { companyRoutes } from './company.routes';
 import { groupCustomerRoutes } from './group-customer.routes';
 import { itemPriceRoutes } from './item-price.routes';
+import { laporanPenerimaanBarangRoutes } from './laporan-penerimaan-barang.routes';
 
 export default async (fastify: App) => {
   fastify.register(authRoutes, { prefix: '/auth' });
@@ -45,4 +46,5 @@ export default async (fastify: App) => {
   fastify.register(groupCustomerRoutes, { prefix: '/group-customers' });
   fastify.register(historyPengirimanRoutes, { prefix: '/history-pengiriman' });
   fastify.register(itemPriceRoutes, { prefix: '/item-prices' });
+  fastify.register(laporanPenerimaanBarangRoutes, { prefix: '/laporan-penerimaan-barang' });
 };

--- a/src/routes/laporan-penerimaan-barang.routes.ts
+++ b/src/routes/laporan-penerimaan-barang.routes.ts
@@ -1,0 +1,120 @@
+import { FastifyPluginCallback, FastifyPluginOptions } from 'fastify';
+import { LaporanPenerimaanBarangController } from '@/controllers/laporan-penerimaan-barang.controller';
+import { validateRequest } from '@/middleware/validate-request';
+import {
+  createLaporanPenerimaanBarangSchema,
+  CreateLaporanPenerimaanBarangInput,
+  deleteLaporanPenerimaanBarangSchema,
+  getAllLaporanPenerimaanBarangSchema,
+  getLaporanPenerimaanBarangSchema,
+  searchLaporanPenerimaanBarangSchema,
+  updateLaporanPenerimaanBarangSchema,
+  UpdateLaporanPenerimaanBarangInput,
+  GetAllLaporanPenerimaanBarangInput,
+  SearchLaporanPenerimaanBarangInput,
+} from '@/schemas/laporan-penerimaan-barang.schema';
+
+export const laporanPenerimaanBarangRoutes: FastifyPluginCallback<FastifyPluginOptions> = (
+  fastify,
+  _options,
+  done
+) => {
+  fastify.get<{ Querystring: SearchLaporanPenerimaanBarangInput['query'] }>(
+    '/search',
+    {
+      schema: {
+        tags: ['Laporan Penerimaan Barang'],
+        querystring: searchLaporanPenerimaanBarangSchema.shape.query,
+        security: [{ Bearer: [] }],
+      },
+      preHandler: [
+        fastify.authenticate,
+        validateRequest(searchLaporanPenerimaanBarangSchema),
+      ],
+    },
+    LaporanPenerimaanBarangController.search
+  );
+
+  fastify.post<{ Body: CreateLaporanPenerimaanBarangInput }>(
+    '/',
+    {
+      schema: {
+        tags: ['Laporan Penerimaan Barang'],
+        body: createLaporanPenerimaanBarangSchema.shape.body,
+        security: [{ Bearer: [] }],
+      },
+      preHandler: [
+        fastify.authenticate,
+        validateRequest(createLaporanPenerimaanBarangSchema),
+      ],
+    },
+    LaporanPenerimaanBarangController.create
+  );
+
+  fastify.get<{ Querystring: GetAllLaporanPenerimaanBarangInput['query'] }>(
+    '/',
+    {
+      schema: {
+        tags: ['Laporan Penerimaan Barang'],
+        querystring: getAllLaporanPenerimaanBarangSchema.shape.query,
+        security: [{ Bearer: [] }],
+      },
+      preHandler: [
+        fastify.authenticate,
+        validateRequest(getAllLaporanPenerimaanBarangSchema),
+      ],
+    },
+    LaporanPenerimaanBarangController.getAll
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    '/:id',
+    {
+      schema: {
+        tags: ['Laporan Penerimaan Barang'],
+        params: getLaporanPenerimaanBarangSchema.shape.params,
+        security: [{ Bearer: [] }],
+      },
+      preHandler: [
+        fastify.authenticate,
+        validateRequest(getLaporanPenerimaanBarangSchema),
+      ],
+    },
+    LaporanPenerimaanBarangController.getById
+  );
+
+  fastify.put<{ Params: { id: string }; Body: UpdateLaporanPenerimaanBarangInput['body'] }>(
+    '/:id',
+    {
+      schema: {
+        tags: ['Laporan Penerimaan Barang'],
+        params: updateLaporanPenerimaanBarangSchema.shape.params,
+        body: updateLaporanPenerimaanBarangSchema.shape.body,
+        security: [{ Bearer: [] }],
+      },
+      preHandler: [
+        fastify.authenticate,
+        validateRequest(updateLaporanPenerimaanBarangSchema),
+      ],
+    },
+    LaporanPenerimaanBarangController.update
+  );
+
+  fastify.delete<{ Params: { id: string } }>(
+    '/:id',
+    {
+      schema: {
+        tags: ['Laporan Penerimaan Barang'],
+        params: deleteLaporanPenerimaanBarangSchema.shape.params,
+        security: [{ Bearer: [] }],
+      },
+      preHandler: [
+        fastify.authenticate,
+        validateRequest(deleteLaporanPenerimaanBarangSchema),
+      ],
+    },
+    LaporanPenerimaanBarangController.delete
+  );
+
+  done();
+};

--- a/src/schemas/laporan-penerimaan-barang.schema.ts
+++ b/src/schemas/laporan-penerimaan-barang.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { paginationSchema } from './pagination.schema';
+
+export const createLaporanPenerimaanBarangSchema = z.object({
+  body: z.object({
+    purchaseOrderId: z.string({ required_error: 'Purchase Order ID is required' }).describe('The ID of the related purchase order'),
+    tanggal_po: z.coerce.date().optional().describe('The purchase order date'),
+    customerId: z.string({ required_error: 'Customer ID is required' }).describe('The ID of the related customer'),
+    alamat_customer: z.string().optional().describe('Customer address'),
+    termin_bayar: z.string().optional().describe('The ID of the payment term'),
+    statusId: z.string().optional().describe('The ID of the status'),
+    files: z.array(z.string()).optional().describe('List of uploaded file IDs associated with the report'),
+  }),
+});
+
+export const getLaporanPenerimaanBarangSchema = z.object({
+  params: z.object({
+    id: z.string().describe('The ID of the goods receipt report'),
+  }),
+});
+
+export const updateLaporanPenerimaanBarangSchema = z.object({
+  params: z.object({
+    id: z.string().describe('The ID of the goods receipt report'),
+  }),
+  body: z.object({
+    purchaseOrderId: z.string().optional().describe('The ID of the related purchase order'),
+    tanggal_po: z.coerce.date().optional().describe('The purchase order date'),
+    customerId: z.string().optional().describe('The ID of the related customer'),
+    alamat_customer: z.string().optional().describe('Customer address'),
+    termin_bayar: z.string().optional().describe('The ID of the payment term'),
+    statusId: z.string().optional().describe('The ID of the status'),
+    files: z.array(z.string()).optional().describe('List of uploaded file IDs associated with the report'),
+  }),
+});
+
+export const deleteLaporanPenerimaanBarangSchema = z.object({
+  params: z.object({
+    id: z.string().describe('The ID of the goods receipt report'),
+  }),
+});
+
+export const getAllLaporanPenerimaanBarangSchema = z.object({
+  query: paginationSchema,
+});
+
+export const searchLaporanPenerimaanBarangSchema = z.object({
+  query: z
+    .object({
+      q: z.string().optional().describe('Search keyword'),
+    })
+    .merge(paginationSchema),
+});
+
+export type CreateLaporanPenerimaanBarangInput = z.infer<typeof createLaporanPenerimaanBarangSchema>['body'];
+export type UpdateLaporanPenerimaanBarangInput = z.infer<typeof updateLaporanPenerimaanBarangSchema>;
+export type GetAllLaporanPenerimaanBarangInput = z.infer<typeof getAllLaporanPenerimaanBarangSchema>;
+export type SearchLaporanPenerimaanBarangInput = z.infer<typeof searchLaporanPenerimaanBarangSchema>;

--- a/src/services/laporan-penerimaan-barang.service.ts
+++ b/src/services/laporan-penerimaan-barang.service.ts
@@ -1,0 +1,252 @@
+import { LaporanPenerimaanBarang, Prisma } from '@prisma/client';
+import { prisma } from '@/config/database';
+import {
+  CreateLaporanPenerimaanBarangInput,
+  UpdateLaporanPenerimaanBarangInput,
+} from '@/schemas/laporan-penerimaan-barang.schema';
+import { BaseService } from './base.service';
+import { PaginatedResult } from '@/types/common.types';
+import { AppError } from '@/utils/app-error';
+
+export class LaporanPenerimaanBarangService extends BaseService<
+  LaporanPenerimaanBarang,
+  CreateLaporanPenerimaanBarangInput,
+  UpdateLaporanPenerimaanBarangInput['body']
+> {
+  protected modelName = 'LaporanPenerimaanBarang';
+  protected tableName = 'LaporanPenerimaanBarang';
+  protected prismaModel = prisma.laporanPenerimaanBarang;
+
+  private static includeRelations = {
+    purchaseOrder: true,
+    customer: true,
+    termOfPayment: true,
+    status: true,
+    files: true,
+  } satisfies Prisma.LaporanPenerimaanBarangInclude;
+
+  static async createLaporanPenerimaanBarang(
+    data: CreateLaporanPenerimaanBarangInput,
+    userId: string
+  ): Promise<LaporanPenerimaanBarang> {
+    const service = new LaporanPenerimaanBarangService();
+
+    await service.validateRelations(data);
+
+    const preprocessData = (
+      payload: CreateLaporanPenerimaanBarangInput,
+      actorId: string
+    ) => {
+      const { tanggal_po, files, ...rest } = payload;
+      return {
+        ...rest,
+        tanggal_po: tanggal_po ? new Date(tanggal_po) : undefined,
+        files: files && files.length > 0 ? { connect: files.map((id) => ({ id })) } : undefined,
+        createdBy: actorId,
+        updatedBy: actorId,
+      };
+    };
+
+    return service.createEntity(data, userId, preprocessData);
+  }
+
+  static async getAllLaporanPenerimaanBarang(
+    page: number = 1,
+    limit: number = 10
+  ): Promise<PaginatedResult<LaporanPenerimaanBarang>> {
+    const service = new LaporanPenerimaanBarangService();
+    return service.getAllEntities(page, limit, this.includeRelations);
+  }
+
+  static async getLaporanPenerimaanBarangById(id: string) {
+    const service = new LaporanPenerimaanBarangService();
+    return service.getEntityById(id, this.includeRelations);
+  }
+
+  static async updateLaporanPenerimaanBarang(
+    id: string,
+    data: UpdateLaporanPenerimaanBarangInput['body'],
+    userId: string
+  ): Promise<LaporanPenerimaanBarang> {
+    const service = new LaporanPenerimaanBarangService();
+
+    await service.validateRelations(data, id);
+
+    const preprocessData = (
+      payload: UpdateLaporanPenerimaanBarangInput['body'],
+      actorId: string
+    ) => {
+      const { tanggal_po, files, ...rest } = payload;
+      return {
+        ...rest,
+        tanggal_po: tanggal_po ? new Date(tanggal_po) : undefined,
+        files:
+          files !== undefined
+            ? { set: files.map((id) => ({ id })) }
+            : undefined,
+        updatedBy: actorId,
+      };
+    };
+
+    return service.updateEntity(id, data, userId, preprocessData);
+  }
+
+  static async deleteLaporanPenerimaanBarang(
+    id: string,
+    userId: string
+  ): Promise<LaporanPenerimaanBarang> {
+    const service = new LaporanPenerimaanBarangService();
+    return service.deleteEntity(id, userId);
+  }
+
+  static async searchLaporanPenerimaanBarang(
+    query: string | undefined,
+    page: number = 1,
+    limit: number = 10
+  ): Promise<PaginatedResult<LaporanPenerimaanBarang>> {
+    const service = new LaporanPenerimaanBarangService();
+
+    if (!query) {
+      return service.getAllEntities(page, limit, this.includeRelations);
+    }
+
+    const filters: Prisma.LaporanPenerimaanBarangWhereInput[] = [
+      {
+        alamat_customer: {
+          contains: query,
+          mode: 'insensitive',
+        },
+      },
+      {
+        files: {
+          some: {
+            filename: {
+              contains: query,
+              mode: 'insensitive',
+            },
+          },
+        },
+      },
+      {
+        purchaseOrder: {
+          po_number: {
+            contains: query,
+            mode: 'insensitive',
+          },
+        },
+      },
+      {
+        customer: {
+          namaCustomer: {
+            contains: query,
+            mode: 'insensitive',
+          },
+        },
+      },
+      {
+        termOfPayment: {
+          kode_top: {
+            contains: query,
+            mode: 'insensitive',
+          },
+        },
+      },
+      {
+        status: {
+          status_name: {
+            contains: query,
+            mode: 'insensitive',
+          },
+        },
+      },
+    ];
+
+    return service.searchEntities(
+      filters,
+      page,
+      limit,
+      this.includeRelations
+    );
+  }
+
+  private async validateRelations(
+    data:
+      | CreateLaporanPenerimaanBarangInput
+      | UpdateLaporanPenerimaanBarangInput['body'],
+    entityId?: string
+  ) {
+    const { purchaseOrderId, customerId, termin_bayar, statusId, files } = data;
+
+    if (purchaseOrderId) {
+      const purchaseOrder = await prisma.purchaseOrder.findUnique({
+        where: { id: purchaseOrderId },
+      });
+      if (!purchaseOrder) {
+        throw new AppError('Purchase Order not found', 404);
+      }
+    } else if (!entityId) {
+      throw new AppError('Purchase Order ID is required', 400);
+    }
+
+    if (customerId) {
+      const customer = await prisma.customer.findUnique({
+        where: { id: customerId },
+      });
+      if (!customer) {
+        throw new AppError('Customer not found', 404);
+      }
+    } else if (!entityId) {
+      throw new AppError('Customer ID is required', 400);
+    }
+
+    if (termin_bayar) {
+      const termOfPayment = await prisma.termOfPayment.findUnique({
+        where: { id: termin_bayar },
+      });
+      if (!termOfPayment) {
+        throw new AppError('Term of Payment not found', 404);
+      }
+    }
+
+    if (statusId) {
+      const status = await prisma.status.findUnique({
+        where: { id: statusId },
+      });
+      if (!status) {
+        throw new AppError('Status not found', 404);
+      }
+    }
+
+    if (files && files.length > 0) {
+      const uploadedFiles = await prisma.fileUploaded.findMany({
+        where: {
+          id: { in: files },
+        },
+        select: {
+          id: true,
+          laporanPenerimaanBarangId: true,
+        },
+      });
+
+      if (uploadedFiles.length !== files.length) {
+        throw new AppError('One or more files not found', 404);
+      }
+
+      const conflictingFile = uploadedFiles.find((file) => {
+        if (!file.laporanPenerimaanBarangId) {
+          return false;
+        }
+
+        if (!entityId) {
+          return true;
+        }
+
+        return file.laporanPenerimaanBarangId !== entityId;
+      });
+
+      if (conflictingFile) {
+        throw new AppError('One or more files are already linked to another report', 400);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- rename the Prisma model and migration to `laporan_penerimaan_barang`, adding status and file relations plus updated seeds for the new status category
- update the laporan penerimaan barang service, controller, schema, and routes to manage status validation and multi-file associations
- refresh the Bruno collection and README to reflect the laporan penerimaan barang endpoints and request payload changes

## Testing
- npm run build *(fails: pre-existing TypeScript errors in test and legacy modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d0267f7ccc8331b708921374dee71e