### PR TITLE
Fix filename generation without extension

### DIFF
--- a/src/__tests__/utils/random.utils.test.ts
+++ b/src/__tests__/utils/random.utils.test.ts
@@ -80,7 +80,7 @@ describe('random.utils', () => {
 
     it('should handle filename without extension', () => {
       const filename = generateFilenameWithPrefix('BULK', 'document');
-      expect(filename).toMatch(/^BULK_document_[0-9a-f]{4}\.document$/);
+      expect(filename).toMatch(/^BULK_document_[0-9a-f]{4}$/);
     });
 
     it('should handle filename with multiple dots', () => {

--- a/src/utils/random.utils.ts
+++ b/src/utils/random.utils.ts
@@ -233,10 +233,10 @@ export function generateFilenameWithPrefix(
 ): string {
   const randomString = generateRandomString(randomBytesLength);
   const filenameParts = originalFilename.split('.');
-  
+
   if (filenameParts.length === 1) {
     // File without extension
-    return `${prefix}_${originalFilename}_${randomString}.${originalFilename}`;
+    return `${prefix}_${originalFilename}_${randomString}`;
   }
   
   const extension = filenameParts.pop();


### PR DESCRIPTION
## Summary
- update `generateFilenameWithPrefix` to avoid appending a fake extension when the original filename lacks one
- adjust the unit test to expect filenames without extensions to omit the trailing period segment

## Testing
- npm test -- --runTestsByPath src/__tests__/utils/random.utils.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0a55ea4788331aca584b9a60c7a96